### PR TITLE
Replace app group and extension IDs with tokyo.kaito

### DIFF
--- a/Recoreon/Recoreon.entitlements
+++ b/Recoreon/Recoreon.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.com.github.umireon.Recoreon</string>
+		<string>group.tokyo.kaito.Recoreon</string>
 	</array>
 </dict>
 </plist>

--- a/Recoreon/UI/RecoreonBroadcastPickerRepresentable.swift
+++ b/Recoreon/UI/RecoreonBroadcastPickerRepresentable.swift
@@ -10,7 +10,7 @@ struct RecoreonBroadcastPickerRepresentable: UIViewRepresentable {
 
   func makeUIView(context: Context) -> some UIView {
     let picker = RPSystemBroadcastPickerView()
-    picker.preferredExtension = "com.github.umireon.Recoreon.RecoreonBroadcastUploadExtension"
+    picker.preferredExtension = "com.tokyo.kaito.Recoreon.RecoreonBroadcastUploadExtension"
     picker.showsMicrophoneButton = true
     if let button = picker.subviews.first as? UIButton {
       button.frame = CGRect(origin: .zero, size: picker.bounds.size)

--- a/RecoreonBroadcastUploadExtension/RecoreonBroadcastUploadExtension.entitlements
+++ b/RecoreonBroadcastUploadExtension/RecoreonBroadcastUploadExtension.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.com.github.umireon.Recoreon</string>
+		<string>group.tokyo.kaito.Recoreon</string>
 	</array>
 </dict>
 </plist>

--- a/RecoreonBroadcastUploadExtension/SampleHandler.swift
+++ b/RecoreonBroadcastUploadExtension/SampleHandler.swift
@@ -21,7 +21,7 @@ class SampleHandler: RPBroadcastSampleHandler {
   let recoreonPathService = RecoreonPathService(fileManager: FileManager.default)
   let appGroupsUserDefaults = AppGroupsPreferenceService.userDefaults
 
-  let logger = Logger(label: "com.github.umireon.Recoreon.RecoreonBroadcastUploadExtension")
+  let logger = Logger(label: "tokyo.kaito.Recoreon.RecoreonBroadcastUploadExtension")
 
   var firstVideoFrameArrived = false
 

--- a/RecoreonCommon/RecoreonCommon.swift
+++ b/RecoreonCommon/RecoreonCommon.swift
@@ -1,1 +1,1 @@
-let appGroupsIdentifier = "group.com.github.umireon.Recoreon"
+let appGroupsIdentifier = "group.tokyo.kaito.Recoreon"


### PR DESCRIPTION
This pull request updates the app's bundle and group identifiers to reflect a new organization or namespace, ensuring consistency across the codebase and entitlements. The changes affect configuration files, Swift constants, and logger labels.

Identifier and entitlement updates:

* Changed the app group identifier in `Recoreon/Recoreon.entitlements`, `RecoreonBroadcastUploadExtension/RecoreonBroadcastUploadExtension.entitlements`, and the `appGroupsIdentifier` constant in `RecoreonCommon/RecoreonCommon.swift` from `group.com.github.umireon.Recoreon` to `group.tokyo.kaito.Recoreon`. [[1]](diffhunk://#diff-38801a07279deaf69102d9e8e979fe2bfd4192600515005a0fd3b57d3c3f1facL7-R7) [[2]](diffhunk://#diff-51bb6a0a572fa23924d6adc69bb9567972de5b9f6f3311bfdf73c1dac17fc4eaL1-R1)

Bundle and extension references:

* Updated the `preferredExtension` property in `Recoreon/UI/RecoreonBroadcastPickerRepresentable.swift` to use the new extension identifier `com.tokyo.kaito.Recoreon.RecoreonBroadcastUploadExtension`.
* Changed the logger label in `RecoreonBroadcastUploadExtension/SampleHandler.swift` to match the new bundle identifier `tokyo.kaito.Recoreon.RecoreonBroadcastUploadExtension`.Rename app group and related identifiers to use the tokyo.kaito.Recoreon namespace for consistency. Updated Recoreon.entitlements and RecoreonBroadcastUploadExtension.entitlements (app group string), RecoreonBroadcastPickerRepresentable (preferredExtension string), SampleHandler logger label, and RecoreonCommon.appGroupsIdentifier. Ensure provisioning profiles and App Group settings are updated to match the new identifier.